### PR TITLE
Optimise RUN step & other cleanups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,8 @@
 FROM uselagoon/php-7.4-cli-drupal:latest
 
 LABEL maintainer="marji@morpht.com"
-
-USER root
-
-RUN rm -rf /opt/drupal
-
-RUN composer self-update --2
-
-RUN apk --update add git
-
 LABEL org.opencontainers.image.source="https://github.com/morpht/ci-php-7.4"
+
+RUN rm -rf /opt/drupal \
+  && composer self-update --2 \
+  && apk --no-cache --update add git


### PR DESCRIPTION
Groups `LABEL` together at top of file
Removed `USER` because the upstream container is already using root
Merged `RUN`s into a single step
Added ` --no-cache` to `apk add` call to avoid writing index file to disk

The end result is an image which is 2Mb or ~0.25% smaller with a more readable `Dockerfile`.