### PR TITLE
Added mysql-client pkg and pdo_mysql php extension.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,11 @@ ENV COMPOSER_VERSION=2.1.3 \
 RUN apk add --no-cache --update git \
         bash \
         openssh-client \
+        mysql-client \
         patch \
         rsync \
         libpng libpng-dev \
-    && docker-php-ext-install gd \
+    && docker-php-ext-install gd pdo pdo_mysql \
     && apk del libpng-dev \
     && rm -rf /var/cache/apk/* \
     && curl -L -o /usr/local/bin/composer https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar \


### PR DESCRIPTION
I believe _mysqli_ PHP extension is not needed, Drupal 8 lists _pdo_ as the requirement (not _mysqli_).
https://www.drupal.org/docs/system-requirements/database-server-requirements