### PR TITLE
PHP 7.4.33 alpine3.16, composer 2.4.4, added zip extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN apk add --no-cache --update git \
         mysql-client \
         patch \
         rsync \
-        libpng libpng-dev \
-    && docker-php-ext-install gd pdo pdo_mysql \
+        libpng libpng-dev libzip-dev \
+    && docker-php-ext-install gd pdo pdo_mysql zip \
     && apk del libpng-dev \
     && rm -rf /var/cache/apk/* \
     && curl -L -o /usr/local/bin/composer https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM php:7.4.33-fpm-alpine3.16
 LABEL maintainer="marji@morpht.com"
 LABEL org.opencontainers.image.source="https://github.com/morpht/ci-php-7.4"
 
-ENV COMPOSER_VERSION=2.3.10 \
-  COMPOSER_HASH_SHA256=d808272f284fa8e0f8b470703e1438ac8f362030bbc9d12e29530277d767aff0
+ENV COMPOSER_VERSION=2.4.4 \
+  COMPOSER_HASH_SHA256=c252c2a2219956f88089ffc242b42c8cb9300a368fd3890d63940e4fc9652345
 
 RUN apk add --no-cache --update git \
         bash \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM php:7.4.29-fpm-alpine3.14
+FROM php:7.4.33-fpm-alpine3.16
 
 LABEL maintainer="marji@morpht.com"
 LABEL org.opencontainers.image.source="https://github.com/morpht/ci-php-7.4"
 
-ENV COMPOSER_VERSION=2.3.5 \
-  COMPOSER_HASH_SHA256=3b3b5a899c06a46aec280727bdf50aad14334f6bc40436ea76b07b650870d8f4
+ENV COMPOSER_VERSION=2.3.10 \
+  COMPOSER_HASH_SHA256=d808272f284fa8e0f8b470703e1438ac8f362030bbc9d12e29530277d767aff0
 
 RUN apk add --no-cache --update git \
         bash \

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # ci-php-7.4
 
-Docker image based on the official dockerhub image php:7.4-fpm-alpine3.14
+Docker image based on the official dockerhub image php:7.4-fpm-alpine3.16
 
 A few modifications:
 
-- added composer v2.2.x
+- added composer v2.4.x
 - installed several packages, e.g. git and mysql-client
-- added php extensions - gd, pdo_mysql
+- added php extensions - gd, pdo_mysql, zip
 
 Published in GHCR - https://github.com/orgs/morpht/packages/container/package/ci-php-7.4


### PR DESCRIPTION
Bumping the base container to PHP 7.4.33 on Alpine 3.16
Composer is now 2.4.4
Added php zip extension.